### PR TITLE
Open files in right buffer instead of sidebar

### DIFF
--- a/denops/ranger/main.ts
+++ b/denops/ranger/main.ts
@@ -154,7 +154,33 @@ export async function main(denops: Denops): Promise<void> {
         if (!node) return;
 
         if (node.type === "file") {
-          // Open file in Neovim
+          // Open file in right buffer (not in sidebar)
+          // First, try to use the previous window (the one active before opening sidebar)
+          let targetWinid = globalState.prevWinid;
+
+          // Check if prevWinid is still valid and not the sidebar itself
+          if (!targetWinid || !await isValidWin(denops, targetWinid) || targetWinid === globalState.winid) {
+            // Find a non-sidebar window to open the file in
+            const windows = await denops.call("nvim_list_wins") as number[];
+            for (const winid of windows) {
+              if (winid !== globalState.winid) {
+                targetWinid = winid;
+                break;
+              }
+            }
+
+            // If no other window exists, create one to the right of sidebar
+            if (!targetWinid || targetWinid === globalState.winid) {
+              // Move to sidebar window first
+              await denops.call("nvim_set_current_win", globalState.winid);
+              // Create a new window to the right
+              await denops.cmd("rightbelow vertical split");
+              targetWinid = await denops.call("nvim_get_current_win") as number;
+            }
+          }
+
+          // Switch to target window and open file
+          await denops.call("nvim_set_current_win", targetWinid);
           await denops.cmd(`edit ${node.path}`);
         } else {
           // Expand/collapse directory


### PR DESCRIPTION
## Summary
- Enhanced file opening behavior to open files in the right buffer while keeping the sidebar open
- Improves user experience by preserving the tree view during file navigation
- Focus automatically moves to the opened file buffer

## Changes
Modified the `open()` function in `denops/ranger/main.ts`:
- Files now open in the previous window (active before sidebar was opened) if still valid
- Falls back to finding any non-sidebar window
- Creates a new window to the right of sidebar if no valid window exists
- Focus automatically moves to the opened file buffer after opening

## Behavior
**Before:**
- Pressing Enter on a file would execute `edit` in the sidebar buffer
- Sidebar would be replaced with the file content
- Tree view would be lost

**After:**
- Pressing Enter on a file opens it in the right buffer
- Sidebar remains visible on the left
- Focus moves to the opened file
- Tree view is preserved for continued navigation

## Test Plan
- [x] Type checking passes (`deno check denops/ranger/main.ts`)
- [ ] Manual testing: Open sidebar, press Enter on a file, verify it opens in right buffer
- [ ] Manual testing: Verify sidebar remains visible after opening file
- [ ] Manual testing: Verify focus moves to the opened file
- [ ] Manual testing: Test with no existing windows (should create new window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)