### PR TITLE
Preserve directory expansion state across sidebar toggles (Fixes #17)

### DIFF
--- a/denops/ranger/main.ts
+++ b/denops/ranger/main.ts
@@ -12,7 +12,9 @@ import type { TreeState } from "../../src/models/types.ts";
 import { updateState } from "../../src/models/tree-state.ts";
 import {
   buildTree,
+  collectExpandedPaths,
   getVisibleNodes,
+  restoreExpandedState,
   toggleNode,
   updateNodeInTree,
 } from "../../src/services/tree-builder.ts";
@@ -100,8 +102,22 @@ export async function main(denops: Denops): Promise<void> {
         // Set the buffer in the sidebar window
         await denops.call("nvim_set_current_buf", bufnr);
 
+        // Collect expanded paths from previous tree (if exists)
+        const expandedPaths = globalState?.rootNode
+          ? collectExpandedPaths(globalState.rootNode)
+          : new Set<string>();
+
         // Build tree from current directory
-        const rootNode = buildTree(cwd, globalState?.showHidden ?? false);
+        let rootNode = buildTree(cwd, globalState?.showHidden ?? false);
+
+        // Restore expansion state
+        if (expandedPaths.size > 0) {
+          rootNode = restoreExpandedState(
+            rootNode,
+            expandedPaths,
+            globalState?.showHidden ?? false,
+          );
+        }
 
         // Update global state
         globalState = {
@@ -472,8 +488,17 @@ export async function main(denops: Denops): Promise<void> {
         // Toggle showHidden flag
         const showHidden = !globalState.showHidden;
 
+        // Collect expanded paths before rebuilding
+        const expandedPaths = collectExpandedPaths(globalState.rootNode);
+
         // Refresh tree with new visibility
-        const rootNode = buildTree(globalState.rootPath, showHidden);
+        let rootNode = buildTree(globalState.rootPath, showHidden);
+
+        // Restore expansion state
+        if (expandedPaths.size > 0) {
+          rootNode = restoreExpandedState(rootNode, expandedPaths, showHidden);
+        }
+
         globalState = updateState(globalState, { showHidden, rootNode });
 
         // Re-render
@@ -570,8 +595,21 @@ export async function main(denops: Denops): Promise<void> {
       if (!globalState) return;
 
       try {
+        // Collect expanded paths before rebuilding
+        const expandedPaths = collectExpandedPaths(globalState.rootNode);
+
         // Rebuild tree from scratch
-        const rootNode = buildTree(globalState.rootPath, globalState.showHidden);
+        let rootNode = buildTree(globalState.rootPath, globalState.showHidden);
+
+        // Restore expansion state
+        if (expandedPaths.size > 0) {
+          rootNode = restoreExpandedState(
+            rootNode,
+            expandedPaths,
+            globalState.showHidden,
+          );
+        }
+
         globalState = { ...globalState, rootNode };
 
         // Re-render

--- a/src/services/tree-builder.ts
+++ b/src/services/tree-builder.ts
@@ -302,3 +302,74 @@ export function updateNodeInTree(
     children: updatedChildren,
   };
 }
+
+/**
+ * Collect all expanded directory paths from a tree.
+ *
+ * Recursively traverses the tree and collects paths of all directories
+ * that have expanded=true. Used to preserve expansion state when
+ * rebuilding the tree.
+ *
+ * @param root - Root DirectoryNode to collect from
+ * @returns Set of absolute paths for all expanded directories
+ */
+export function collectExpandedPaths(root: DirectoryNode): Set<string> {
+  const expandedPaths = new Set<string>();
+
+  function traverse(node: TreeNode) {
+    if (node.type === "directory") {
+      // Add this directory if it's expanded
+      if (node.expanded) {
+        expandedPaths.add(node.path);
+      }
+
+      // Recursively traverse children
+      for (const child of node.children) {
+        traverse(child);
+      }
+    }
+  }
+
+  traverse(root);
+  return expandedPaths;
+}
+
+/**
+ * Restore expansion state to a tree based on a set of expanded paths.
+ *
+ * Takes a freshly built tree and expands directories whose paths are
+ * in the expandedPaths set. This preserves user's expansion state
+ * across tree rebuilds (e.g., when toggling sidebar or refreshing).
+ *
+ * Constitutional requirement: Uses synchronous operations only.
+ * Silently skips paths that no longer exist (e.g., deleted directories).
+ *
+ * @param root - Root DirectoryNode to restore expansion state to
+ * @param expandedPaths - Set of paths that should be expanded
+ * @param showHidden - Whether to include hidden files/directories
+ * @returns New tree with expansion state restored
+ */
+export function restoreExpandedState(
+  root: DirectoryNode,
+  expandedPaths: Set<string>,
+  showHidden: boolean,
+): DirectoryNode {
+  // If this directory should be expanded, expand it
+  let updatedRoot = root;
+  if (expandedPaths.has(root.path)) {
+    updatedRoot = expandNode(root, showHidden);
+  }
+
+  // Recursively restore expansion state for children
+  const updatedChildren = updatedRoot.children.map((child) => {
+    if (child.type === "directory" && expandedPaths.has(child.path)) {
+      return restoreExpandedState(child, expandedPaths, showHidden);
+    }
+    return child;
+  });
+
+  return {
+    ...updatedRoot,
+    children: updatedChildren,
+  };
+}


### PR DESCRIPTION
## Summary
Fixes #17

When toggling the sidebar with `:RangerOpen`, directory expansion state is now preserved. Previously, all directories would collapse when reopening the sidebar, forcing users to re-expand them.

## Changes
- **Added `collectExpandedPaths()`** to `src/services/tree-builder.ts`
  - Recursively collects paths of all expanded directories from a tree
- **Added `restoreExpandedState()`** to `src/services/tree-builder.ts`
  - Restores expansion state to a freshly built tree based on collected paths
  - Silently skips paths that no longer exist (e.g., deleted directories)
- **Updated `openTree()`** in `denops/ranger/main.ts`
  - Collects expansion state before rebuilding tree
  - Restores expansion state after building new tree
- **Updated `refresh()`** in `denops/ranger/main.ts`
  - Preserves expansion state when refreshing tree (R key)
- **Updated `toggleHidden()`** in `denops/ranger/main.ts`
  - Preserves expansion state when toggling hidden files (H key)

## Behavior

### Before
1. `:RangerOpen` to open sidebar
2. Expand a directory (Tab or Enter)
3. `:RangerOpen` to close sidebar
4. `:RangerOpen` to reopen sidebar
5. ❌ **Previously expanded directory is now collapsed**

### After
1. `:RangerOpen` to open sidebar
2. Expand a directory (Tab or Enter)
3. `:RangerOpen` to close sidebar
4. `:RangerOpen` to reopen sidebar
5. ✅ **Previously expanded directory remains expanded**

### Additional Benefits
- Expansion state persists when refreshing tree (R key)
- Expansion state persists when toggling hidden files (H key)
- Deleted directories are gracefully handled (no errors)

## Technical Details
- All operations remain **synchronous** per constitutional requirements
- Uses existing `expandNode()` and `loadChildren()` functions
- Tree structure remains **immutable** (new tree created on rebuild)
- No changes to `TreeState` interface (expansion paths collected dynamically)

## Test Plan
- [x] Type checking passes (`deno check`)
- [ ] Manual test: Expand directories → close sidebar → reopen → verify state persisted
- [ ] Manual test: Expand directories → refresh (R) → verify state persisted
- [ ] Manual test: Expand directories → toggle hidden (H) → verify state persisted
- [ ] Manual test: Expand directory → delete it externally → refresh → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)